### PR TITLE
Adds webrick gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'webrick'
 
 group :test do
     gem "html-proofer"


### PR DESCRIPTION
Cloning the repo in a new computer I found that jekyll was complaining about a missing gem.
Per https://github.com/jekyll/jekyll/issues/8523 it seems that Ruby 3.0 doesn't include webrick, this PR adds it to the Gemfile